### PR TITLE
Refactor master and worker IPs

### DIFF
--- a/14_kubernetes_cluster/K8_installation.md
+++ b/14_kubernetes_cluster/K8_installation.md
@@ -45,14 +45,14 @@ The cluster will contain the master node and worker nodes, most of the configura
 
 The configuration will have the following nodes
 
-- Master Node:  192.168.56.100 – master.example.com
+- Master Node:  192.168.56.101 – master.example.com
 - First Worker Node:  192.168.56.101 – worker1.example.com
 - Second Worker Node:  192.168.56.102 – worker2.example.com
 
 1. For interworking, all the three nodes will have the configuration in the `/etc/hosts` file.
 
 ```
-192.168.56.100   master.example.com   master
+192.168.56.101   master.example.com   master
 192.168.56.101   worker1.example.com worker1
 192.168.56.102   worker2.example.com worker2
 ```

--- a/14_kubernetes_cluster/K8_installation.md
+++ b/14_kubernetes_cluster/K8_installation.md
@@ -46,15 +46,15 @@ The cluster will contain the master node and worker nodes, most of the configura
 The configuration will have the following nodes
 
 - Master Node:  192.168.56.101 – master.example.com
-- First Worker Node:  192.168.56.101 – worker1.example.com
-- Second Worker Node:  192.168.56.102 – worker2.example.com
+- First Worker Node:  192.168.56.111 – worker1.example.com
+- Second Worker Node:  192.168.56.112 – worker2.example.com
 
 1. For interworking, all the three nodes will have the configuration in the `/etc/hosts` file.
 
 ```
 192.168.56.101   master.example.com   master
-192.168.56.101   worker1.example.com worker1
-192.168.56.102   worker2.example.com worker2
+192.168.56.111   worker1.example.com worker1
+192.168.56.112   worker2.example.com worker2
 ```
 
 2. Disabling swap

--- a/14_kubernetes_cluster/Vagrantfile
+++ b/14_kubernetes_cluster/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "master" do |master|
     master.vm.box = BASE_BOX_IMAGE
     master.vm.hostname = "master.example.com"
-    master.vm.network "private_network", ip: "192.168.56.100"
+    master.vm.network "private_network", ip: "192.168.56.101"
     master.vm.network "forwarded_port", guest: 6443, host: 6443
     master.vm.provider "virtualbox" do |vb|
       vb.name = "master"
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
       config.vm.define "worker#{i}" do |worker|
         worker.vm.box = BASE_BOX_IMAGE
         worker.vm.hostname = "worker#{i}.example.com"
-        worker.vm.network "private_network", ip: "192.168.56.10#{i}"
+        worker.vm.network "private_network", ip: "192.168.56.11#{i}"
         worker.vm.provider "virtualbox" do |vb|
           vb.name = "worker#{i}"
           vb.cpus = CPUS_WORKER

--- a/14_kubernetes_cluster/common.sh
+++ b/14_kubernetes_cluster/common.sh
@@ -4,7 +4,7 @@
 # 1. Hostnames
 
 sudo tee /etc/hosts > /dev/null <<EOF
-192.168.56.100   master.example.com   master
+192.168.56.101   master.example.com   master
 192.168.56.101   worker1.example.com worker1
 192.168.56.102   worker2.example.com worker2
 EOF

--- a/14_kubernetes_cluster/common.sh
+++ b/14_kubernetes_cluster/common.sh
@@ -5,8 +5,8 @@
 
 sudo tee /etc/hosts > /dev/null <<EOF
 192.168.56.101   master.example.com   master
-192.168.56.101   worker1.example.com worker1
-192.168.56.102   worker2.example.com worker2
+192.168.56.111   worker1.example.com worker1
+192.168.56.112   worker2.example.com worker2
 EOF
 
 # 2. Disable the swap

--- a/14_kubernetes_cluster/master.sh
+++ b/14_kubernetes_cluster/master.sh
@@ -3,7 +3,7 @@
 
 kubeadm config images pull
 
-sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --control-plane-endpoint=master.example.com --ignore-preflight-errors=all  --apiserver-advertise-address=192.168.56.100
+sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --control-plane-endpoint=master.example.com --ignore-preflight-errors=all  --apiserver-advertise-address=192.168.56.101
 
 
 # Configure kubeconfig for the master


### PR DESCRIPTION
Hey there, first of all, thanks for this repo. It is helpful for Kubernetes beginners.

I have been working on this setup for a bit at my home lab [on my own fork](https://github.com/gitperr/vagrant-kubernetes), and noticed that there are a few issues.

One of them is the worker node interface not coming up, or so we thought. At the end of your video, you are pinging the worker node from master to provide a fix: https://youtu.be/sgCojrRmYwM?t=736

I found a more robust fix for this problem while researching. Seems like the IP with ending `.100` that is being used on the master node is the designated DHCP server IP for VirtualBox. You can verify it like so (considering this path is where your VirtualBox is):
```
cd "C:\Program Files\Oracle\VirtualBox"
VBoxManage list dhcpservers
```
Now, instead of using that designated DHCP server IP and confusing our worker nodes, we will have to change it from `100` to something else. In this PR, I'll change it to `101` and refactor the worker nodes to accompany these changes. This is not set in stone though, you can use any other IP you wish as long as it is not `100` ending.

Hope this helps solve this issue. Care to try and let me know how it goes for you?